### PR TITLE
refactor topk gating

### DIFF
--- a/python/dlBLAS/benchmarks/topk_gating.py
+++ b/python/dlBLAS/benchmarks/topk_gating.py
@@ -5,7 +5,7 @@ import torch.nn.functional as F
 from torch import Tensor
 import triton
 import time
-
+from torch.profiler import profile, record_function, ProfilerActivity
 import dlblas
 from dlblas.utils.gpu_helper import get_idle_device 
 
@@ -219,7 +219,7 @@ def test():
     output2_torch = out_torch_pack.token_rearranged_ec_idx
     output3_torch = out_torch_pack.token_exp_weights
     output4_torch = out_torch_pack.expert_select_token_idx
-    output1_triton, output2_triton, output3_triton, output4_triton = model_triton(logits_triton, k, capacity_factor, min_capacity, True)
+    output1_triton, output2_triton, output3_triton, output4_triton = model_triton(logits_triton, k, capacity_factor, min_capacity, False)
 
     assert output1_torch.shape == output1_triton.shape
     assert torch.allclose(output1_torch, output1_triton)
@@ -246,6 +246,28 @@ def test():
     
     assert logits_torch.grad.shape == logits_triton.grad.shape
     assert torch.allclose(logits_torch.grad, logits_triton.grad, rtol = 1e-8, atol = 1e-8)
+    
+    if False:
+        with profile(
+                    activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
+                    record_shapes = False,
+                    profile_memory = False,
+                    with_stack = False,
+                    with_flops = False,
+                    with_modules = False,) as prof:
+            output1_torch, out_torch_pack = model_torch(logits_torch, k, capacity_factor, min_capacity, enable_token_rearrange_opt)
+            output1_triton, output2_triton, output3_triton, output4_triton = model_triton(logits_triton, k, capacity_factor, min_capacity, True)
+            loss_torch = torch.sum(torch.mean(output1_torch * output3_torch))
+            loss_triton = torch.sum(torch.mean(output1_triton * output3_triton))
+            dout_torch = torch.randn_like(loss_torch)
+            with torch.no_grad():
+                dout_triton = dout_torch.clone()
+            loss_torch.backward(dout_torch, retain_graph=True)
+            loss_triton.backward(dout_triton, retain_graph=True)
+            assert torch.allclose(logits_torch.grad, logits_triton.grad, rtol = 1e-8, atol = 1e-8)
+        prof.export_chrome_trace(f"./trace_{time.time_ns()}.json")
+
+    
     # vary seq length for fixed head and batch=4
     configs = []
 
@@ -268,7 +290,7 @@ def test():
     @triton.testing.perf_report(configs)
     def bench_top2gating(SeqLen, op, provider, device=device_):
         warmup = 100
-        rep = 100
+        rep = 500
         shape = (SeqLen, NumberExperts)
         logits = torch.randn(shape, device=device, requires_grad=True)
 

--- a/python/dlBLAS/dlblas/kernels/topk_gating_fwd_part1.py
+++ b/python/dlBLAS/dlblas/kernels/topk_gating_fwd_part1.py
@@ -3,12 +3,14 @@ import triton
 import triton.language as tl
 import triton.language.core as tlc
 from dlblas.utils import register_dlblas_op, SymVar, Tensor, ChoiceSpace
+from dlblas.utils.libentry import libentry
 if triton.__version__ >= "3.0.0":
     from triton.language.extra.cuda.libdevice import fast_expf as tl_exp
 else:
     from triton.language.math import fast_expf as tl_exp
 
 
+@libentry()
 @triton.autotune(
     configs = [
         triton.Config({'BLOCK_S': BS}, num_stages=s, num_warps=w) \
@@ -51,7 +53,7 @@ def _topk_gating_kernel_part1(
         max_idx = tl.argmax(gates_data, axis = 1, tie_break_left=False)
         mask_data = tl.zeros((BLOCK_S, EXPERTS), tl.int64)
         all_ids = tl.broadcast_to(tl.arange(0, EXPERTS)[None,:], (BLOCK_S, EXPERTS))
-        max_idx = tl.broadcast_to(tl.reshape(max_idx, (BLOCK_S, 1)), (BLOCK_S, EXPERTS))
+        max_idx = tl.broadcast_to(tl.expand_dims(max_idx, axis=1), (BLOCK_S, EXPERTS))
         mask_data = tl.where(all_ids == max_idx, 1, mask_data)
         masks_ptrs = masks_ptr + idx * seq_len * EXPERTS + offs_s * stride_s + offs_e
         tl.store(masks_ptrs, mask_data, mask=offs_s < seq_len)
@@ -64,18 +66,18 @@ def call(logits: torch.Tensor, k: int):
     gates = torch.empty_like(logits)
     masks = torch.empty((k, s, e), dtype=torch.int64, device=logits.device)
     fill_value = torch.finfo(logits.dtype).min
-
     grid = lambda META: (triton.cdiv(s, META["BLOCK_S"]), )
-    _topk_gating_kernel_part1[grid](
-        logits,
-        masks,
-        gates,
-        fill_value,
-        stride_se_s,
-        seq_len = s,
-        K = k,
-        EXPERTS = e,
-    )
+    with torch.cuda.device(gates.device):
+        _topk_gating_kernel_part1[grid](
+            logits,
+            masks,
+            gates,
+            fill_value,
+            stride_se_s,
+            seq_len = s,
+            K = k,
+            EXPERTS = e,
+        )
     return gates, masks
 
 

--- a/python/dlBLAS/dlblas/kernels/topk_gating_fwd_part3.py
+++ b/python/dlBLAS/dlblas/kernels/topk_gating_fwd_part3.py
@@ -3,8 +3,10 @@ import triton
 import triton.language as tl
 import triton.language.core as tlc
 from dlblas.utils import register_dlblas_op, SymVar, Tensor, ChoiceSpace
+from dlblas.utils.libentry import libentry
 
 
+@libentry()
 @triton.jit
 def _topk_gating_fwd_part3_rearrange_opt(
     gates,
@@ -27,30 +29,21 @@ def _topk_gating_fwd_part3_rearrange_opt(
     offs_k = tl.arange(0, BLOCK_K)
     s_pid = tl.program_id(axis=0)
     offs_e = tl.arange(0, EXPERTS)[None,:]
-    
-
     locations_ptrs = locations + offs_k[:,None] * stride_kse_k + s_pid * stride_kse_s + offs_e
     locations_data = tl.load(locations_ptrs, mask=offs_k[:,None] < K)
     masks_ptrs = masks + offs_k[:,None] * stride_kse_k + s_pid * stride_kse_s + offs_e
     masks_data = tl.load(masks_ptrs, mask=offs_k[:,None] < K)
     masks_data *= tl.where(locations_data < CAPACITY, 1, 0)
-
     # for bwd
     tl.store(masks_ptrs, masks_data, mask=offs_k[:,None] < K)
-
     locations_data *= masks_data
     locations_ks_data = tl.sum(locations_data, axis=1)
-    
     gates_ptrs = gates + s_pid * stride_se_s + offs_e
-   
-    
     gates_data = tl.load(gates_ptrs)
     #gate_s = torch.einsum("se,kse->ks", gates, mask_float)
     multi = tl.broadcast_to(gates_data, (BLOCK_K, EXPERTS)) * masks_data
-
     # gates_s = tl.sum(multi, axis=1)
     gates_ks, indices_ks = tl.max(multi, axis=1, return_indices=True)
-
     denom_s = tl.sum(gates_ks, axis=0)
     # torch.clamp
     denom_s = tl.where(denom_s < min_value, min_value, denom_s)
@@ -58,21 +51,18 @@ def _topk_gating_fwd_part3_rearrange_opt(
     gates_ks /= denom_s
     gate_ks_ptrs = gate_ks_ptr + offs_k * stride_ks_k + s_pid
     tl.store(gate_ks_ptrs, gates_ks, mask=offs_k < K)
-
-   
     token_rearranged_ec_idx_data = indices_ks.to(tl.int32) * CAPACITY + locations_ks_data.to(tl.int32)
     token_rearranged_ec_idx_ptrs = token_rearranged_ec_idx_ptr + offs_k * stride_ks_k + s_pid
     tl.store(token_rearranged_ec_idx_ptrs, token_rearranged_ec_idx_data, mask=offs_k < K)
-
     # se
     invers_k_data = tl.load(invers_k_ptr + offs_k, mask=offs_k < K)
-    token_sel_exp_int_mask_data = masks_data * tl.broadcast_to(tl.reshape(invers_k_data,(BLOCK_K,1)), (BLOCK_K, EXPERTS))
+    token_sel_exp_int_mask_data = masks_data * tl.broadcast_to(tl.expand_dims(invers_k_data,axis=1), (BLOCK_K, EXPERTS))
     token_sel_exp_int_mask_data = tl.sum(token_sel_exp_int_mask_data, axis=0)
     token_sel_exp_int_mask_ptrs = token_sel_exp_int_mask_ptr + s_pid * stride_se_s + tl.arange(0, EXPERTS)
     tl.store(token_sel_exp_int_mask_ptrs, token_sel_exp_int_mask_data)
     
 
-
+@libentry()
 @triton.jit
 def _topk_gating_fwd_part3(
     gates,
@@ -98,52 +88,38 @@ def _topk_gating_fwd_part3(
     offs_k = tl.arange(0, BLOCK_K)[:,None]
     s_pid = tl.program_id(axis=0)
     offs_e = tl.arange(0, EXPERTS)[None,:]
-    
-
     locations_ptrs = locations + offs_k * stride_kse_k + s_pid * stride_kse_s + offs_e
     locations_data = tl.load(locations_ptrs, mask=offs_k < K)
     masks_ptrs = masks + offs_k * stride_kse_k + s_pid * stride_kse_s + offs_e
     masks_data = tl.load(masks_ptrs, mask=offs_k < K)
     masks_data *= tl.where(locations_data < CAPACITY, 1, 0)
-
     # for bwd
     tl.store(masks_ptrs, masks_data, mask=offs_k < K)
-
     locations_data *= masks_data
     locations_s_data = tl.reshape(tl.sum(locations_data, axis=1), (BLOCK_K, 1))
-    
     gates_ptrs = gates + s_pid * stride_se_s + offs_e
-   
-    
     gates_data = tl.load(gates_ptrs)
     #gate_s = torch.einsum("se,kse->ks", gates, mask_float)
     multi = tl.broadcast_to(gates_data, (BLOCK_K, EXPERTS)) * masks_data
     gates_s = tl.sum(multi, axis=1)
-
     denom_s = tl.sum(gates_s, axis=0)
     # torch.clamp
     denom_s = tl.where(denom_s < min_value, min_value, denom_s)
-
     gates_s /= denom_s
     gates_s = tl.reshape(gates_s, (BLOCK_K, 1))
     gates_all_data = tl.broadcast_to(gates_s, (BLOCK_K, EXPERTS)) * masks_data.to(gates_s.dtype)
-
     # test
     gates_all_ptrs = gates_all + offs_k * stride_kse_k + s_pid * stride_kse_s + offs_e
     tl.store(gates_all_ptrs, gates_all_data, mask=offs_k < K)
     locas_s_ptrs = locations_s + offs_k * stride_ks_k + s_pid
     tl.store(locas_s_ptrs, locations_s_data, mask=offs_k < K)
-
     # locations_s = tl.broadcast_to(tl.reshape(locations_s,(BLOCK_K, 1)), (BLOCK_K, BLOCK_C))
     # one_hot_help = tl.broadcast_to(tl.reshape(tl.arange(0, BLOCK_C), (1,BLOCK_C)), (BLOCK_K, BLOCK_C))
     # loc_sc = tl.where(locations_s == one_hot_help, 1, 0)
     # loc_sc = tl.broadcast_to(tl.reshape(loc_sc,(BLOCK_K, 1, BLOCK_C)), (BLOCK_K, EXPERTS, BLOCK_C))
     # gates_all_data = tl.broadcast_to(tl.reshape(gates_all_data,(BLOCK_K, EXPERTS,1)), (BLOCK_K, EXPERTS, BLOCK_C))
-
     # combine_weights_data = tl.reshape(tl.sum(gates_all_data * loc_sc, axis=0), (1, EXPERTS, BLOCK_C))
-    
     # offs_ksc = s_pid * stride_sec_s + tl.arange(0, EXPERTS)[None,:,None] * stride_sec_e + tl.arange(0, BLOCK_C)[None, None, :] 
-   
     # mask_ = tl.arange(0, BLOCK_C)[None, None, :]  < CAPACITY
     # tl.store(combine_weights + offs_ksc, combine_weights_data, mask=mask_)
     # tl.store(dispatch_mask + offs_ksc, tl.where(combine_weights_data > 0, 1, 0), mask=mask_)
@@ -159,31 +135,31 @@ def call(gates, masks, locations, k, capacity, enable_token_rearrange_opt):
 def rearrange_opt(gates, masks, locations, k, capacity):
     s, e = gates.shape
     invers_k = torch.arange(k, 0, -1, device=masks.device)
-
     token_rearranged_ec_idx = torch.empty((k, s), dtype=torch.int32, device=gates.device)
     gate_ks = torch.empty((k, s), dtype=gates.dtype, device=gates.device)
     token_sel_exp_int_mask = torch.empty((s, e), dtype=torch.int64, device=gates.device)
     stride_se_s, _ = gates.stride()
     stride_ks_k, _ = gate_ks.stride()
     stride_kse_k, stride_kse_s, _ = masks.stride()
-    _topk_gating_fwd_part3_rearrange_opt[(s,)](
-        gates,
-        locations,
-        masks,
-        invers_k,
-        token_rearranged_ec_idx,
-        gate_ks,
-        token_sel_exp_int_mask,
-        stride_ks_k,
-        stride_se_s,
-        stride_kse_k,
-        stride_kse_s,
-        CAPACITY = capacity,
-        min_value = torch.finfo(gates.dtype).eps,
-        K = k,
-        EXPERTS = e,
-        BLOCK_K = triton.next_power_of_2(k),
-    )
+    with torch.cuda.device(gates.device):
+        _topk_gating_fwd_part3_rearrange_opt[(s,)](
+            gates,
+            locations,
+            masks,
+            invers_k,
+            token_rearranged_ec_idx,
+            gate_ks,
+            token_sel_exp_int_mask,
+            stride_ks_k,
+            stride_se_s,
+            stride_kse_k,
+            stride_kse_s,
+            CAPACITY = capacity,
+            min_value = torch.finfo(gates.dtype).eps,
+            K = k,
+            EXPERTS = e,
+            BLOCK_K = triton.next_power_of_2(k),
+        )
     expert_sel_top_c_token_idx = torch.topk(
             token_sel_exp_int_mask, k=capacity, dim=0, sorted=True
     )[1]
@@ -203,34 +179,32 @@ def topk_gating_fwd_part3(gates, masks, locations, k, capacity):
     stride_sec_s, stride_sec_e, _ = combine_weights.stride()
     stride_kse_k, stride_kse_s, _ = masks.stride()
     min_value = torch.finfo(gates.dtype).eps
-    
-    _topk_gating_fwd_part3[(s,)](
-        gates,
-        gates_all,
-        locations,
-        locations_s,
-        masks,
-        combine_weights,
-        dispatch_mask,
-        stride_ks_k=s,
-        stride_se_s=stride_se_s,
-        stride_kse_k=stride_kse_k,
-        stride_kse_s=stride_kse_s,
-        stride_sec_s=stride_sec_s, 
-        stride_sec_e=stride_sec_e,
-        CAPACITY = capacity,
-        BLOCK_C = triton.next_power_of_2(capacity),
-        min_value = min_value,
-        K = k,
-        EXPERTS = e,
-        BLOCK_K = triton.next_power_of_2(k),
-    )
-
+    with torch.cuda.device(gates.device):
+        _topk_gating_fwd_part3[(s,)](
+            gates,
+            gates_all,
+            locations,
+            locations_s,
+            masks,
+            combine_weights,
+            dispatch_mask,
+            stride_ks_k=s,
+            stride_se_s=stride_se_s,
+            stride_kse_k=stride_kse_k,
+            stride_kse_s=stride_kse_s,
+            stride_sec_s=stride_sec_s, 
+            stride_sec_e=stride_sec_e,
+            CAPACITY = capacity,
+            BLOCK_C = triton.next_power_of_2(capacity),
+            min_value = min_value,
+            K = k,
+            EXPERTS = e,
+            BLOCK_K = triton.next_power_of_2(k),
+        )
     locations_sc = torch.nn.functional.one_hot(locations_s, num_classes=capacity)
     combine_sec = torch.einsum("kse,ksc->ksec", gates_all, locations_sc)
     combine_weights = torch.sum(combine_sec, dim=0)
     dispatch_mask = combine_weights.bool()
-
     return combine_weights, dispatch_mask
 
 

--- a/python/dlBLAS/dlblas/utils/gpu_helper.py
+++ b/python/dlBLAS/dlblas/utils/gpu_helper.py
@@ -1,4 +1,7 @@
 import subprocess
+import torch
+
+DEVICE_COUNT = torch.cuda.device_count()
 
 def is_gpu_idle(gpu_id):
     try:
@@ -23,7 +26,7 @@ def is_gpu_idle(gpu_id):
         raise RuntimeError("Failed to check GPU status:{e}")
 
 def get_idle_device():
-    for gpu_id in range(8):
+    for gpu_id in range(DEVICE_COUNT):
         if is_gpu_idle(gpu_id) == True:
             print(f"GPU {gpu_id} is idle, we will use cuda:{gpu_id}")
             return f"cuda:{gpu_id}"

--- a/python/dlBLAS/dlblas/utils/libentry.py
+++ b/python/dlBLAS/dlblas/utils/libentry.py
@@ -1,0 +1,154 @@
+# modify from https://github.com/FlagOpen/FlagGems
+import inspect
+import threading
+
+import torch
+import triton
+
+DEVICE_COUNT = torch.cuda.device_count()
+
+
+class LibEntry(triton.KernelInterface):
+    def __init__(
+        self,
+        fn,
+    ):
+        self.fn = fn
+        self.arg_names = fn.arg_names
+        self.divisibility = 16
+        self.kernel_cache = tuple(dict() for _ in range(DEVICE_COUNT))
+
+        fn = self.fn
+        while not isinstance(fn, triton.runtime.JITFunction):
+            fn = fn.fn
+        self.jit_function: triton.runtime.JITFunction = fn
+        self.specialize_indices = [
+            p.num
+            for p in self.jit_function.params
+            if not p.is_constexpr and not p.do_not_specialize
+        ]
+        self.do_not_specialize_indices = [
+            p.num
+            for p in self.jit_function.params
+            if not p.is_constexpr and p.do_not_specialize
+        ]
+        self.lock = threading.Lock()
+
+    def key(self, spec_args, dns_args, const_args):
+        spec_key = [
+            (arg.dtype, arg.data_ptr() % self.divisibility == 0)
+            if hasattr(arg, "data_ptr")
+            else (type(arg), arg)
+            for arg in spec_args
+        ]
+        dns_key = [
+            arg.dtype
+            if hasattr(arg, "data_ptr")
+            else type(arg)
+            if not isinstance(arg, int)
+            else "i32"
+            if -(2**31) <= arg and arg <= 2**31 - 1
+            else "u64"
+            if 2**63 <= arg and arg <= 2**64 - 1
+            else "i64"
+            for arg in dns_args
+        ]
+        # const args passed by position
+        return tuple(spec_key + dns_key + const_args)
+
+    def run(self, *args, **kwargs):
+        grid = kwargs["grid"]
+        # collect all the arguments
+        spec_args = []  # specialize arguments
+        dns_args = []  # do not specialize arguments
+        const_args = []  # constexpr arguments
+        k_args = []  # kernel arguments
+        for i, arg in enumerate(args):
+            if i in self.specialize_indices:
+                k_args.append(arg)
+                spec_args.append(arg)
+            elif i in self.do_not_specialize_indices:
+                k_args.append(arg)
+                dns_args.append(arg)
+            else:
+                const_args.append(arg)
+        for p in self.jit_function.params[len(args) :]:
+            if p.name in kwargs:
+                val = kwargs[p.name]
+            elif p.default is inspect._empty:
+                continue
+            else:
+                val = p.default
+
+            if p.is_constexpr:
+                const_args.append(val)
+            elif p.do_not_specialize:
+                dns_args.append(val)
+                k_args.append(val)
+            else:
+                spec_args.append(val)
+                k_args.append(val)
+
+        entry_key = self.key(spec_args, dns_args, const_args)
+        device = torch.cuda.current_device()
+        cache = self.kernel_cache[device]
+        while entry_key not in cache:
+            # NOTE: we serialize the first run of a jit function regardless of which device to run on
+            # because Triton runtime is currently not threadsafe.
+            with self.lock:
+                if entry_key in cache:
+                    break
+                kernel = self.fn.run(*args, **kwargs)
+                fn = self.fn
+                # collect constexpr arguments for grid computation
+                constexprs = {}
+                while not isinstance(fn, triton.runtime.JITFunction):
+                    if isinstance(fn, triton.runtime.Autotuner):
+                        config = fn.best_config
+                        constexprs["num_warps"] = config.num_warps
+                        constexprs["num_stages"] = config.num_stages
+                        constexprs["num_ctas"] = config.num_ctas
+                        constexprs = {**constexprs, **config.kwargs}
+                    elif isinstance(fn, triton.runtime.Heuristics):
+                        for v, heur in fn.values.items():
+                            constexprs[v] = heur(
+                                {
+                                    **dict(zip(fn.arg_names, args)),
+                                    **kwargs,
+                                    **constexprs,
+                                }
+                            )
+                    else:
+                        raise RuntimeError("Invalid Runtime Function")
+                    fn = fn.fn
+                for p in self.jit_function.params:
+                    if p.is_constexpr and p.name not in constexprs:
+                        constexprs[p.name] = p.default
+                cache[entry_key] = (kernel, constexprs)
+            return kernel, constexprs
+
+        kernel, constexprs = cache[entry_key]
+
+        if callable(grid):
+            # collect all arguments to the grid fn，ie:
+            # 1. args,
+            # 2. kwargs,
+            # 3. all all other captured arguments in CompiledKernel from Autotunner & Heuristics
+            # when kwargs & captured args conflict, captured args have higher priority
+            meta = {**dict(zip(self.arg_names, args)), **kwargs, **constexprs}
+            grid = grid(meta)
+        grid = grid + (1, 1)
+
+        kernel[grid[0:3]](*k_args)
+        return kernel, constexprs
+
+
+def libentry():
+    """
+    Decorator for triton library entries.
+    """
+
+    def decorator(fn):
+        return LibEntry(fn)
+
+    return decorator


### PR DESCRIPTION
1. 把tl.reshape改为expand_dims来兼容Triton2.1
2. 复用openGems里的libentry，降低Triton jit 运行时开销，减少timeline空泡
![img_v3_02e0_104f7bb7-7151-4054-b499-746151b2498g](https://github.com/user-attachments/assets/152e7b73-3a5d-4d4c-ab51-d6f094961532)
