### PR TITLE
fix(triton): enable auto blockify loop to fix 'coreDim=13824000 can't be greater than UINT16_MAX'

### DIFF
--- a/test/ascend/passed_tests/test_add.py
+++ b/test/ascend/passed_tests/test_add.py
@@ -65,6 +65,9 @@ def test_case(param_list):
 @pytest.mark.parametrize('param_list',
                          [
                              ['float32', (2, 4096, 8), 2, 32768, 1024],
+                             ['float32', (128, 4096, 1280), 1310720, 512, 64],
+                             ['float16', (128, 4096, 1280), 1310720, 512, 64],
+                             ['int8', (128, 4096, 1280), 1310720, 512, 64],
                          ]
                          )
 def test_all_blocks_parallel(param_list, monkeypatch):


### PR DESCRIPTION
Added env variable TRITON_ALL_BLOCKS_PARALLEL. When enabled, the compiler automatically optimizes logical blocks to physical blocks, reducing runtime overhead and enabling compiler optimizations such as auto multi-buffer.